### PR TITLE
Create key ID index to find user names / pubkeys

### DIFF
--- a/iron-gpg.h
+++ b/iron-gpg.h
@@ -40,8 +40,8 @@ extern const char * iron_pubkey_file(const char * login);
 extern int  write_gpg_encrypted_file(const char * fname, char * enc_fname);
 extern int  write_gpg_decrypted_file(const char * fname, char * dec_fname);
 
-extern void iron_reset_recipients(void);
-extern void iron_list_recipients(void);
+extern void iron_clear_recipients(void);
+extern void iron_show_recipients(void);
 extern int  iron_add_recipient(const char * login);
 extern int  iron_remove_recipient(const char * login);
 extern int  iron_index_user(const char * login);

--- a/iron-gpg.h
+++ b/iron-gpg.h
@@ -24,6 +24,11 @@
 #define IRON_PUBKEY_FNAME       ".ironpubkey"   //  Name of the file in user's home dir that holds public key info
 
 
+extern int  iron_initialize(void);
+extern void iron_set_host(const char * hostname);
+extern int  iron_check_keys(void);
+extern int  iron_generate_keys(void);
+
 extern const char * iron_host(void);
 extern const char * iron_user_login(void);
 extern const char * iron_user_ssh_dir(void);
@@ -31,19 +36,15 @@ extern const char * iron_user_ironcore_dir(void);
 extern const char * iron_user_pubkey_file(void);
 extern const char * iron_pubkey_file(const char * login);
 
-extern void iron_set_host(const char * hostname);
-extern int  iron_check_keys(void);
-extern int  iron_generate_keys(void);
-
 
 extern int  write_gpg_encrypted_file(const char * fname, char * enc_fname);
 extern int  write_gpg_decrypted_file(const char * fname, char * dec_fname);
 
-extern void iron_reset_recipients();
+extern void iron_reset_recipients(void);
+extern void iron_list_recipients(void);
 extern int  iron_add_recipient(const char * login);
 extern int  iron_remove_recipient(const char * login);
-
+extern int  iron_index_user(const char * login);
 extern int  iron_extension_offset(const char * name);
-
 
 #endif  /* _IRON_GPG_H */

--- a/iron/gpg-internal.h
+++ b/iron/gpg-internal.h
@@ -32,7 +32,6 @@
 #define IRONCORE_SUBDIR         "ironcore/"     //  subdir of ~/.ssh that holds all IronCore files
 
 
-extern int          iron_initialize(void);
 extern u_int32_t    iron_gpg_now();
 
 #endif

--- a/iron/gpg-keyfile.h
+++ b/iron/gpg-keyfile.h
@@ -27,6 +27,12 @@ extern int      get_gpg_secret_encryption_key(const gpg_public_key * pub_keys, u
 
 extern int      get_gpg_secret_signing_key(Key * rsa_key);
 
+extern int	iron_index_public_keys(gpg_public_key * keys);
+
 extern int      iron_retrieve_ssh_private_key(const char * prompt, Key ** key);
+
+extern char *   iron_get_user_by_key_id(const char * key_id);
+
+extern gpg_public_key * iron_get_user_keys_by_key_id(const char * key_id);
 
 #endif

--- a/iron/gpg-keyfile.h
+++ b/iron/gpg-keyfile.h
@@ -27,7 +27,7 @@ extern int      get_gpg_secret_encryption_key(const gpg_public_key * pub_keys, u
 
 extern int      get_gpg_secret_signing_key(Key * rsa_key);
 
-extern int	iron_index_public_keys(gpg_public_key * keys);
+extern int      iron_index_public_keys(gpg_public_key * keys);
 
 extern int      iron_retrieve_ssh_private_key(const char * prompt, Key ** key);
 

--- a/iron/recipient.c
+++ b/iron/recipient.c
@@ -126,9 +126,9 @@ iron_add_recipient(const char * login)
 {
     int retval = 0;
 
-	/*  In case this is called before anything else has accessed the list - we want to make sure that the
-	 *  first entry in the list is always the current user.
-	 */
+    /*  In case this is called before anything else has accessed the list - we want to make sure that the
+     *  first entry in the list is always the current user.
+     */
     if (num_recipients == 0 && strcmp(login, iron_user_login()) != 0) iron_add_recipient(iron_user_login());
 
     for (int i = 0; i < num_recipients; i++) {
@@ -150,7 +150,7 @@ iron_add_recipient(const char * login)
             new_ent->rsa_key.ecdsa_nid  = -1;
             if (get_gpg_public_keys(login, &(new_ent->rsa_key), new_ent->signer_fp, new_ent->key, &key_len,
                                     new_ent->fp) == 0) {
-				if (strcmp(login, iron_user_login()) != 0) iron_index_public_keys(new_ent);
+                if (strcmp(login, iron_user_login()) != 0) iron_index_public_keys(new_ent);
                 num_recipients++;
             } else {
                 error("Unable to retrieve public key information for user %s", login);
@@ -227,14 +227,14 @@ void
 iron_list_recipients(void)
 {
 
-	const gpg_public_key * recip_list;
-	int rct = iron_get_recipients(&recip_list);
-	if (rct >= 0) {
-		logit("Currently registered recipients:");
-		for (int i = 0; i < rct; i++) {
-			logit("  %s", recip_list[i].login);
-		}
-	} else {
-		error("Unable to retrieve list of recipients.");
-	}
+    const gpg_public_key * recip_list;
+    int rct = iron_get_recipients(&recip_list);
+    if (rct >= 0) {
+        logit("Currently registered recipients:");
+        for (int i = 0; i < rct; i++) {
+            logit("  %s", recip_list[i].login);
+        }
+    } else {
+        error("Unable to retrieve list of recipients.");
+    }
 }

--- a/iron/recipient.c
+++ b/iron/recipient.c
@@ -126,6 +126,9 @@ iron_add_recipient(const char * login)
 {
     int retval = 0;
 
+	/*  In case this is called before anything else has accessed the list - we want to make sure that the
+	 *  first entry in the list is always the current user.
+	 */
     if (num_recipients == 0 && strcmp(login, iron_user_login()) != 0) iron_add_recipient(iron_user_login());
 
     for (int i = 0; i < num_recipients; i++) {
@@ -147,6 +150,7 @@ iron_add_recipient(const char * login)
             new_ent->rsa_key.ecdsa_nid  = -1;
             if (get_gpg_public_keys(login, &(new_ent->rsa_key), new_ent->signer_fp, new_ent->key, &key_len,
                                     new_ent->fp) == 0) {
+				if (strcmp(login, iron_user_login()) != 0) iron_index_public_keys(new_ent);
                 num_recipients++;
             } else {
                 error("Unable to retrieve public key information for user %s", login);
@@ -209,8 +213,28 @@ iron_remove_recipient(const char * login)
  *  user's entry. That one should always be in the list.
  */
 void
-iron_reset_recipients()
+iron_reset_recipients(void)
 {
     if (num_recipients >= 1) num_recipients = 1;
 }
 
+/**
+ *  List the entries in the registered list.
+ *
+ *  For each of the entries (including the current user), display the login.
+ */
+void
+iron_list_recipients(void)
+{
+
+	const gpg_public_key * recip_list;
+	int rct = iron_get_recipients(&recip_list);
+	if (rct >= 0) {
+		logit("Currently registered recipients:");
+		for (int i = 0; i < rct; i++) {
+			logit("  %s", recip_list[i].login);
+		}
+	} else {
+		error("Unable to retrieve list of recipients.");
+	}
+}

--- a/iron/recipient.c
+++ b/iron/recipient.c
@@ -213,7 +213,7 @@ iron_remove_recipient(const char * login)
  *  user's entry. That one should always be in the list.
  */
 void
-iron_reset_recipients(void)
+iron_clear_recipients(void)
 {
     if (num_recipients >= 1) num_recipients = 1;
 }
@@ -224,7 +224,7 @@ iron_reset_recipients(void)
  *  For each of the entries (including the current user), display the login.
  */
 void
-iron_list_recipients(void)
+iron_show_recipients(void)
 {
 
     const gpg_public_key * recip_list;

--- a/sftp-client.c
+++ b/sftp-client.c
@@ -1316,7 +1316,11 @@ do_download(struct sftp_conn *conn, const char *remote_path,
 	max_req = 1;
 	progress_counter = offset;
 
+#ifdef IRONCORE
+	if (decrypt_flag && showprogress && size != 0)
+#else
 	if (showprogress && size != 0)
+#endif
 		start_progress_meter(remote_path, size, &progress_counter);
 
 	while (num_req > 0 || max_req > 0) {
@@ -1440,7 +1444,11 @@ do_download(struct sftp_conn *conn, const char *remote_path,
 		}
 	}
 
+#ifdef IRONCORE
+	if (decrypt_flag && showprogress && size)
+#else
 	if (showprogress && size)
+#endif
 		stop_progress_meter();
 
 	/* Sanity check */

--- a/sftp.c
+++ b/sftp.c
@@ -172,6 +172,9 @@ enum sftp_command {
 #ifdef IRONCORE
 	I_ADD_RCPT,
 	I_RM_RCPT,
+	I_CLR_RCPT,
+	I_SHOW_RCPT,
+	I_FIND_USER,
 #endif
 };
 
@@ -196,9 +199,15 @@ static const struct CMD cmds[] = {
 	{ "chgrp",	I_CHGRP,	REMOTE	},
 	{ "chmod",	I_CHMOD,	REMOTE	},
 	{ "chown",	I_CHOWN,	REMOTE	},
+#ifdef IRONCORE
+	{ "clrrcpt",I_CLR_RCPT,	LOCAL	},
+#endif
 	{ "df",		I_DF,		REMOTE	},
 	{ "dir",	I_LS,		REMOTE	},
 	{ "exit",	I_QUIT,		NOARGS	},
+#ifdef IRONCORE
+	{ "finduser",	I_FIND_USER,	LOCAL	},
+#endif
 	{ "get",	I_GET,		REMOTE	},
 	{ "help",	I_HELP,		NOARGS	},
 	{ "lcd",	I_LCHDIR,	LOCAL	},
@@ -223,6 +232,7 @@ static const struct CMD cmds[] = {
 	{ "rmdir",	I_RMDIR,	REMOTE	},
 #ifdef IRONCORE
 	{ "rmrcpt",	I_RM_RCPT,	LOCAL	},
+	{ "showrcpt",	I_SHOW_RCPT,	LOCAL	},
 #endif
 	{ "symlink",	I_SYMLINK,	REMOTE	},
 	{ "version",	I_VERSION,	NOARGS	},
@@ -274,9 +284,13 @@ help(void)
 	    "chgrp grp path                     Change group of file 'path' to 'grp'\n"
 	    "chmod mode path                    Change permissions of file 'path' to 'mode'\n"
 	    "chown own path                     Change owner of file 'path' to 'own'\n"
+#ifdef IRONCORE
+		"clrrcpt                            Clear all users added to recipient list\n"
+#endif
 	    "df [-hi] [path]                    Display statistics for current directory or\n"
 	    "                                   filesystem containing 'path'\n"
 	    "exit                               Quit sftp\n"
+	    "finduser                           Search for sharing info for login on remote server\n"
 	    "get [-afPpRr] remote [local]       Download file\n"
 	    "reget [-fPpRr] remote [local]      Resume download file\n"
 	    "reput [-fPpRr] [local] remote      Resume upload file\n"
@@ -298,6 +312,7 @@ help(void)
 	    "rmdir path                         Remove remote directory\n"
 #ifdef IRONCORE
 		"rmrcpt login                       Remove login from recipient list\n"
+		"showrcpt                           Show users currently on recipient list\n"
 #endif
 	    "symlink oldpath newpath            Symlink remote file\n"
 	    "version                            Show SFTP version\n"
@@ -1509,6 +1524,7 @@ parse_args(const char **cpp, int *ignore_errors, int *aflag,
 #ifdef IRONCORE
 	case I_ADD_RCPT:
 	case I_RM_RCPT:
+	case I_FIND_USER:
 		if ((optidx = parse_no_flags(cmd, argv, argc)) <= 0)
 			return -1;
 		/* Login is required */
@@ -1517,6 +1533,9 @@ parse_args(const char **cpp, int *ignore_errors, int *aflag,
 			return -1;
 		}
 		*path1 = xstrdup(argv[optidx]);
+		break;
+	case I_SHOW_RCPT:
+	case I_CLR_RCPT:
 		break;
 #endif
 	default:
@@ -1774,6 +1793,20 @@ parse_dispatch_command(struct sftp_conn *conn, const char *cmd, char **pwd,
 	case I_RM_RCPT:
 		if (iron_remove_recipient(path1) == 0) {
 			mprintf("Removed login %s from the recipient list\n", path1);
+		} else {
+			err = 1;
+		}
+		break;
+	case I_CLR_RCPT:
+		iron_reset_recipients();
+		break;
+	case I_SHOW_RCPT:
+		iron_list_recipients();
+		break;
+	case I_FIND_USER:
+		if (retrieve_user_pubkeys(conn, path1) == 0) {
+			mprintf("Found sharing info for login %s\n", path1);
+			if (iron_index_user(path1) != 0) error("Unable to add sharing info to index.");
 		} else {
 			err = 1;
 		}
@@ -2583,6 +2616,9 @@ main(int argc, char **argv)
 	}
 
 #ifdef IRONCORE
+	if (iron_initialize() < 0) {
+		fatal("Unable to intialize secure file sharing.");
+	}
 	iron_set_host(host);
 	/*  Save off the home directory on the remote machine, in case we need it to find other users' pubkeys.  */
 	char * remote_path = do_realpath(conn, ".");

--- a/sftp.c
+++ b/sftp.c
@@ -206,7 +206,7 @@ static const struct CMD cmds[] = {
 	{ "dir",	I_LS,		REMOTE	},
 	{ "exit",	I_QUIT,		NOARGS	},
 #ifdef IRONCORE
-	{ "finduser",	I_FIND_USER,	LOCAL	},
+	{ "finduser",	I_FIND_USER,	REMOTE	},
 #endif
 	{ "get",	I_GET,		REMOTE	},
 	{ "help",	I_HELP,		NOARGS	},
@@ -1798,10 +1798,10 @@ parse_dispatch_command(struct sftp_conn *conn, const char *cmd, char **pwd,
 		}
 		break;
 	case I_CLR_RCPT:
-		iron_reset_recipients();
+		iron_clear_recipients();
 		break;
 	case I_SHOW_RCPT:
-		iron_list_recipients();
+		iron_show_recipients();
 		break;
 	case I_FIND_USER:
 		if (retrieve_user_pubkeys(conn, path1) == 0) {


### PR DESCRIPTION
Any time we fetch a pubkey, generate an index entry that maps the key ID to the user@host name of the pubkey.

Added commands finduser (to fetch pubkey without adding recipient), clrrcpt (to clear recipients), showrcpt (to show current list of recipients).

When downloading an encrypted file, lists the logins of the users where key IDs can be resolved using the index. Lists the count of key IDs that could not be resolved.
