### PR TITLE
Refactor unit tests  to handle code reorg

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -557,18 +557,21 @@ regress/misc/kexfuzz/kexfuzz$(EXEEXT): ${MISC_KEX_FUZZ_OBJS} libssh.a
 	    -lssh -lopenbsd-compat -lssh -lopenbsd-compat $(LIBS)
 
 UNITTESTS_TEST_IRONGPG_OBJS=\
-	regress/unittests/irongpg/iron-gpg-tests.o \
-	iron-sftp-common.o
+	regress/unittests/irongpg/tests.o \
+	regress/unittests/irongpg/test_gpg-key.o \
+	regress/unittests/irongpg/test_gpg-keyfile.o \
+	regress/unittests/irongpg/test_gpg-packet.o \
+	regress/unittests/irongpg/test_gpg-trustdb.o \
+	regress/unittests/irongpg/test_gpg.o \
+	regress/unittests/irongpg/test_recipient.o \
+	regress/unittests/irongpg/test_util.o
 
 regress/unittests/irongpg/test_irongpg$(EXEEXT): \
     ${UNITTESTS_TEST_IRONGPG_OBJS} ${IRON_OBJS} \
     regress/unittests/test_helper/libtest_helper.a libssh.a
 	$(LD) -o $@ $(LDFLAGS) $(UNITTESTS_TEST_IRONGPG_OBJS) \
-	    $(IRON_OBJS) regress/unittests/test_helper/libtest_helper.a \
+	    regress/unittests/test_helper/libtest_helper.a \
 	    -lsodium -lssh -lopenbsd-compat -lssh -lopenbsd-compat $(LIBS)
-
-regress/unittests/irongpg/iron-gpg-tests.o: iron-gpg.c iron-gpg.h
-	$(CC) $(CFLAGS) $(CPPFLAGS) -DTESTING -c iron-gpg.c -o $@
 
 regress-binaries: regress/modpipe$(EXEEXT) \
 	regress/setuid-allowed$(EXEEXT) \

--- a/iron/util.c
+++ b/iron/util.c
@@ -117,12 +117,12 @@ iron_int_to_buf(int val, u_char * buf)
 u_int32_t
 iron_buf_to_int(const u_char * buf)
 {
-    unsigned int len = 0;
+    u_int32_t val = 0;
     for (int i = 0; i < 4; i++) {
-        len = (len << 8) + buf[i];
+        val = (val << 8) + buf[i];
     }
 
-    return len;
+    return val;
 }
 
 /**

--- a/regress/unittests/irongpg/Makefile
+++ b/regress/unittests/irongpg/Makefile
@@ -3,7 +3,10 @@
 TEST_ENV=      "MALLOC_OPTIONS=AFGJPRX"
 
 PROG=test_irongpg
-SRCS=../../../iron-gpg.c
+SRCS=tests.c \
+   test_gpg-key.c test_gpg-keyfile.c test_gpg-packet.c  test_gpg-trustdb.c \
+   test_gpg.c test_recipient.c test_util.c
+   
 REGRESS_TARGETS=run-regress-${PROG}
 
 run-regress-${PROG}: ${PROG}

--- a/regress/unittests/irongpg/test_gpg-key.c
+++ b/regress/unittests/irongpg/test_gpg-key.c
@@ -1,0 +1,36 @@
+#include "regress/unittests/test_helper/test_helper.h"
+
+#include "iron/gpg-key.c"
+
+
+void
+test_s2k(void)
+{
+    TEST_START("s2k");
+
+    static unsigned char salt[S2K_SALT_BYTES] = { 0xfe, 0xdc, 0xba, 0x98, 0x76, 0x54, 0x32, 0x10 };
+    const char * pphrase = "ImGumbyAndYouAreNot";
+
+    static unsigned char expected_key1[AES128_KEY_BYTES] = {
+        0x0e, 0xa5, 0x00, 0x1c, 0xce, 0xad, 0x7e, 0xa8, 0xa0, 0x81, 0x38, 0xae, 0xaf, 0x4e, 0x28, 0xd5
+    };
+    unsigned char s2k_key1[AES128_KEY_BYTES];
+
+    compute_gpg_s2k_key(pphrase, sizeof(s2k_key1), salt, S2K_ITER_BYTE_COUNT, s2k_key1);
+    ASSERT_INT_EQ(memcmp(s2k_key1, expected_key1, sizeof(s2k_key1)), 0);
+
+    //  Second test to handle the case where we need to run multiple hashes to generate enough bits
+    //  Note that the first 16 bytes are the same as the previous test - this is to be expected, since the
+    //  salt and passphrase are the same, so the first hash is executed identically.
+    static unsigned char expected_key2[48] = {
+        0x0e, 0xa5, 0x00, 0x1c, 0xce, 0xad, 0x7e, 0xa8, 0xa0, 0x81, 0x38, 0xae, 0xaf, 0x4e, 0x28, 0xd5,
+        0x21, 0xf1, 0xee, 0x4b, 0x02, 0xc0, 0x0f, 0x63, 0x6a, 0x17, 0xbf, 0x62, 0x34, 0x10, 0x26, 0x48,
+        0x7b, 0xc6, 0x3f, 0x08, 0x9d, 0xb5, 0x6b, 0x34, 0x70, 0x3b, 0x71, 0xdb, 0x67, 0x92, 0x6f, 0x5f
+    };
+    unsigned char s2k_key2[48];
+
+    compute_gpg_s2k_key(pphrase, sizeof(s2k_key2), salt, S2K_ITER_BYTE_COUNT, s2k_key2);
+    ASSERT_INT_EQ(memcmp(s2k_key2, expected_key2, sizeof(s2k_key2)), 0);
+
+    TEST_DONE();
+}

--- a/regress/unittests/irongpg/test_gpg-keyfile.c
+++ b/regress/unittests/irongpg/test_gpg-keyfile.c
@@ -1,0 +1,3 @@
+#include "regress/unittests/test_helper/test_helper.h"
+
+#include "iron/gpg-keyfile.c"

--- a/regress/unittests/irongpg/test_gpg-packet.c
+++ b/regress/unittests/irongpg/test_gpg-packet.c
@@ -1,0 +1,202 @@
+#include "regress/unittests/test_helper/test_helper.h"
+
+#include "iron/gpg-packet.c"
+
+typedef struct tdata {
+    unsigned char * h;
+    size_t h_len;
+    gpg_tag tag;
+    ssize_t size;
+} tdata;
+
+static void
+do_tag_and_size(const tdata * td)
+{
+    unsigned char hdr[8];
+    int retval;
+    gpg_tag tag;
+    ssize_t size;
+
+    retval = extract_gpg_tag_and_size(td->h, &tag, &size);
+    ASSERT_INT_EQ(retval, td->h_len);
+    ASSERT_INT_EQ(tag, td->tag);
+    ASSERT_INT_EQ(size, td->size);
+
+    retval = generate_gpg_tag_and_size(tag, size, hdr);
+    ASSERT_INT_EQ(retval, td->h_len);
+    ASSERT_INT_EQ(memcmp(hdr, td->h, retval), 0);
+}
+
+static void
+do_read_tag_and_size(FILE * infile, const tdata * td)
+{
+    int retval;
+    gpg_tag tag;
+    ssize_t size;
+
+    retval = get_gpg_tag_and_size(infile, &tag, &size);
+    ASSERT_INT_EQ(retval, 0);
+    ASSERT_INT_EQ(tag, td->tag);
+    ASSERT_INT_EQ(size, td->size);
+}
+
+void
+test_tags()
+{
+    TEST_START("tag_and_len");
+
+    unsigned char h0[] = {0x84, 0x00};
+    unsigned char h1[] = {0x88, 0x01};
+    unsigned char h2[] = {0x8d, 0x12, 0x34};
+    unsigned char h3[] = {0x92, 0xfe, 0xdc, 0xba, 0x98};
+    unsigned char h4[] = {0x97};
+    unsigned char h5[] = {0xd1, 0x23};
+    unsigned char h6[] = {0xd2, 0xc1, 0x23};
+    unsigned char h7[] = {0xd3, 0xff, 0x12, 0x34, 0x56, 0x78};
+    unsigned char h8[] = {0xfc, 0xe1};
+        
+    tdata test_item[] = {
+        { h0, sizeof(h0), GPG_TAG_PKESK, 0 },
+        { h1, sizeof(h1), GPG_TAG_SIGNATURE, 1 },
+        { h2, sizeof(h2), GPG_TAG_SKESK, 0x1234 },
+        { h3, sizeof(h3), GPG_TAG_ONE_PASS_SIGNATURE, 0xfedcba98 },
+        { h4, sizeof(h4), GPG_TAG_SECRET_KEY, -1 },
+        { h5, sizeof(h5), GPG_TAG_USER_ATTRIBUTE, 0x23 },
+        { h6, sizeof(h6), GPG_TAG_SEIP_DATA, 0x1e3 },
+        { h7, sizeof(h7), GPG_TAG_MOD_DETECT_CODE, 0x12345678 },
+        { h8, sizeof(h8), GPG_TAG_RESERVED1, 2 },
+    };
+
+    for (size_t i = 0; i < (sizeof(test_item) / sizeof(tdata) - 1); i++) {
+        //  Need to test the "partial length" extract separately, because we don't generate those headers yet
+        do_tag_and_size(test_item + i);
+    }
+    int retval;
+    gpg_tag tag;
+    ssize_t size;
+
+    retval = extract_gpg_tag_and_size(h8, &tag, &size);
+    ASSERT_INT_EQ(retval, sizeof(h8));
+    ASSERT_INT_EQ(tag, GPG_TAG_RESERVED1);
+    ASSERT_INT_EQ(size, 2);
+
+    //  Now try writing a file and testing the functions that read tag and size from the file.
+    FILE * tstfile = tmpfile();
+    for (size_t i = 0; i < (sizeof(test_item) / sizeof(tdata)); i++) {
+        fwrite(test_item[i].h, 1, test_item[i].h_len, tstfile);
+    }
+    rewind(tstfile);
+    
+    for (size_t i = 0; i < (sizeof(test_item) / sizeof(tdata)); i++) {
+        do_read_tag_and_size(tstfile, test_item + i);
+    }
+
+    retval = get_gpg_tag_and_size(tstfile, &tag, &size);    //  Should be at EOF now
+    ASSERT_INT_EQ(retval, -1);
+
+    TEST_DONE();
+}
+
+/*  Retrieve next packet - read header, then read body specified by header length.  */
+static int
+get_gpg_packet(FILE * infile, gpg_packet * pkt)
+{
+    int retval = -1;
+
+    if (get_gpg_tag_and_size(infile, &pkt->tag, &pkt->len) == 0) {
+        if (pkt->len > 0) {
+            unsigned char * buf = malloc(pkt->len);
+            int num_read = fread(buf, sizeof(unsigned char), pkt->len, infile);
+            if (num_read == pkt->len) {
+                pkt->data = sshbuf_from(buf, pkt->len);
+                retval = 0;
+            }
+        }
+    }
+
+    return retval;
+}
+
+static void
+do_put_pkt(FILE * tstfile, tdata * test_item)
+{
+    gpg_packet pkt;
+    pkt.tag = test_item->tag;
+    pkt.len = test_item->size;
+    pkt.data = sshbuf_from(test_item->h, test_item->h_len);
+    int retval = put_gpg_packet(tstfile, &pkt);
+    ASSERT_INT_EQ(retval, 0);
+}
+
+static void
+do_get_pkt(FILE * tstfile, tdata * test_item)
+{
+    gpg_packet pkt;
+    int retval = get_gpg_packet(tstfile, &pkt);
+    ASSERT_INT_EQ(retval, 0);
+    ASSERT_INT_EQ(pkt.tag, test_item->tag);
+    ASSERT_INT_EQ(pkt.len, test_item->size);
+    ASSERT_INT_EQ(pkt.len, test_item->size);
+    ASSERT_INT_EQ(memcmp(sshbuf_ptr(pkt.data), test_item->h, test_item->h_len), 0);
+    sshbuf_free(pkt.data);
+}
+
+void
+test_packets(void)
+{
+    TEST_START("get_and_put_packets");
+
+    //  Some faux GPG messages
+    unsigned char buf[] = {
+        0x84, 0x04, 0x01, 0x23, 0x45, 0x67,
+        0xd1, 0x04, 0x01, 0x23, 0x45, 0x67
+    };
+
+    unsigned char h0[] = {0x01, 0x23, 0x45, 0x67};
+    unsigned char * h1 = malloc(256);
+    for (int i = 0; i < 256; i++) {
+        h1[i] = i;
+    }
+    unsigned char * h2 = malloc(4096);
+    for (int i = 0; i < 4096; i++) {
+        h2[i] = i;
+    }
+        
+    tdata test_item[] = {
+        { h0, sizeof(h0), GPG_TAG_PKESK, sizeof(h0) },          // Hand written from buf
+        { h0, sizeof(h0), GPG_TAG_USER_ATTRIBUTE, sizeof(h0) }, // Hand written from buf
+        { h0, sizeof(h0), GPG_TAG_PKESK, sizeof(h0) },
+        { h1, 256, GPG_TAG_PKESK, 256 },
+        { h2, 4096, GPG_TAG_PKESK, 4096 },
+        { h0, sizeof(h0), GPG_TAG_USER_ATTRIBUTE, sizeof(h0) },
+        { h1, 256, GPG_TAG_USER_ATTRIBUTE, 256 },
+        { h2, 4096, GPG_TAG_USER_ATTRIBUTE, 4096 }
+    };
+
+    FILE * tstfile = tmpfile();
+    fwrite(buf, 1, sizeof(buf), tstfile);
+    for (size_t i = 2; i < sizeof(test_item) / sizeof(tdata); i++) {
+        do_put_pkt(tstfile, test_item + i);
+    }
+    rewind(tstfile);
+
+    for (size_t i = 0; i < sizeof(test_item) / sizeof(tdata); i++) {
+        do_get_pkt(tstfile, test_item + i);
+    }
+
+
+    fclose(tstfile);
+    gpg_packet pkt;
+    int retval = put_gpg_packet(tstfile, &pkt);
+    ASSERT_INT_EQ(retval, -1);
+
+    //  Need to start over with a new empty file because Linux doesn't return an error on fread() of a
+    //  closed file. It happily makes up some random crap. fwrite() on an empty file does seem to return
+    //  an error, though
+    tstfile = tmpfile();
+    retval = get_gpg_packet(tstfile, &pkt);
+    ASSERT_INT_EQ(retval, -1);
+    fclose(tstfile);
+
+    TEST_DONE();
+}

--- a/regress/unittests/irongpg/test_gpg-trustdb.c
+++ b/regress/unittests/irongpg/test_gpg-trustdb.c
@@ -1,0 +1,3 @@
+#include "regress/unittests/test_helper/test_helper.h"
+
+#include "iron/gpg-trustdb.c"

--- a/regress/unittests/irongpg/test_gpg.c
+++ b/regress/unittests/irongpg/test_gpg.c
@@ -1,0 +1,3 @@
+#include "regress/unittests/test_helper/test_helper.h"
+
+#include "iron/gpg.c"

--- a/regress/unittests/irongpg/test_recipient.c
+++ b/regress/unittests/irongpg/test_recipient.c
@@ -1,0 +1,3 @@
+#include "regress/unittests/test_helper/test_helper.h"
+
+#include "iron/recipient.c"

--- a/regress/unittests/irongpg/test_util.c
+++ b/regress/unittests/irongpg/test_util.c
@@ -1,0 +1,245 @@
+#include "regress/unittests/test_helper/test_helper.h"
+
+#include "iron/util.c"
+
+
+void
+test_str2hex(void)
+{
+    TEST_START("str2hex");
+
+    u_char hex1[] = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+
+    char hstr[32];
+
+    iron_hex2str(hex1, sizeof(hex1), hstr);
+    ASSERT_STRING_EQ(hstr,"0123456789ABCDEF"); 
+
+    iron_hex2str(hex1, 0, hstr);
+    ASSERT_STRING_EQ(hstr, "");
+
+    u_char hex[16];
+    int retval = iron_str2hex("0123456789ABCDEF", hex, sizeof(hex));
+    ASSERT_INT_EQ(retval, 8);
+    ASSERT_INT_EQ(memcmp(hex, hex1, retval), 0);
+
+    retval = iron_str2hex("0123456789ABCDEF0123456789ABCDEF0123456789", hex, sizeof(hex));
+    ASSERT_INT_EQ(retval, -1);
+
+    //  Invalid char
+    retval = iron_str2hex("ABCDEFG", hex, sizeof(hex));
+    ASSERT_INT_EQ(retval, -1);
+
+    //  Odd number of chars
+    retval = iron_str2hex("ABCDE", hex, sizeof(hex));
+    ASSERT_INT_EQ(retval, -1);
+
+    TEST_DONE();
+}
+
+void
+test_int_to_buf(void)
+{
+    TEST_START("int2buf");
+
+    u_char buf1[4] = { 0x01, 0x23, 0x45, 0x67 };
+    u_char buf2[4] = { 0xf0, 0x01, 0x02, 0x03 };
+
+    u_char buf[4];
+    iron_int_to_buf(19088743, buf);
+    ASSERT_INT_EQ(memcmp(buf1, buf, 4), 0);
+
+    iron_int_to_buf(4026597891, buf);
+    ASSERT_INT_EQ(memcmp(buf2, buf, 4), 0);
+
+    u_int32_t ival;
+    ival = iron_buf_to_int(buf1);
+    ASSERT_INT_EQ(ival, 19088743);
+
+    ival = iron_buf_to_int(buf2);
+    ASSERT_INT_EQ(ival, 4026597891);
+
+    TEST_DONE();
+}
+
+/*  Read a multi-precision integer of the format used in GPG (two bytes containing the
+ *  length in bits, MSB-first, followed by the bits, MSB first, padded with leading zero bits
+ *  to full octets) and convert it into an OpenSSL BIGNUM.
+ */
+static int
+get_bignum(struct sshbuf * buf, BIGNUM * bignum)
+{
+    int retval = -1;
+
+    u_int16_t len;
+
+    u_char tmp[1024];
+    sshbuf_get_u16(buf, &len);
+    int num_bytes = (len + 7) / 8;
+
+    if (sshbuf_get(buf, tmp, num_bytes) == 0) {
+        BN_bin2bn(tmp, num_bytes, bignum);
+        retval = 0;
+    }
+
+    return retval;
+}
+
+void
+test_bignums(void)
+{
+    TEST_START("bignums");
+
+    static u_char bn1[] = { 0x00, 0x06, 0x23 };
+    static u_char bn2[] = { 0x00, 0x08, 0xa5 };
+    static u_char bn3[] = { 0x00, 0x15, 0x12, 0x34, 0x56 };
+    static u_char bn4[] = {
+        0x01, 0x00,
+        0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff
+    };
+
+
+    typedef struct bndata {
+        u_char * bndata;
+        size_t   bndata_len;
+        int      num_bits;
+    } bndata;
+
+    bndata test_item[] = {
+        { bn1, sizeof(bn1), 6 },
+        { bn2, sizeof(bn2), 8 },
+        { bn3, sizeof(bn3), 21 },
+        { bn4, sizeof(bn4), 256 }
+    };
+
+
+    struct sshbuf * bn_buf = sshbuf_new();
+    BIGNUM * bn = BN_new();
+    for (size_t i = 0; i < sizeof(test_item) / sizeof(bndata); i++) {
+        BN_bin2bn(test_item[i].bndata + 2, test_item[i].bndata_len - 2, bn);
+        iron_put_bignum(bn_buf, bn);
+    }
+
+    u_char tmp[64];
+    for (size_t i = 0; i < sizeof(test_item) / sizeof(bndata); i++) {
+        int retval = get_bignum(bn_buf, bn);
+        ASSERT_INT_EQ(retval, 0);
+        ASSERT_INT_EQ(BN_num_bits(bn), test_item[i].num_bits);
+        int len = BN_bn2bin(bn, tmp);
+        ASSERT_INT_EQ(len, test_item[i].bndata_len - 2);
+        ASSERT_INT_EQ(memcmp(tmp, test_item[i].bndata + 2, len), 0);
+    }
+
+    sshbuf_free(bn_buf);
+    BN_free(bn);
+
+    TEST_DONE();
+}
+
+void
+test_put_num_sexpr(void)
+{
+    TEST_START("put_num_sexpr");
+
+    u_char b1[] = { 0x00 };
+    u_char b2[] = { 0xff };
+    u_char b3[] = { 0x80,
+                    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+                    0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+
+    struct sshbuf * sb = sshbuf_new();
+
+    iron_put_num_sexpr(sb, b1, sizeof(b1));
+    ASSERT_INT_EQ(sshbuf_len(sb), 3);
+    ASSERT_INT_EQ(memcmp(sshbuf_ptr(sb), "1:", 2), 0);
+    ASSERT_INT_EQ(memcmp(sshbuf_ptr(sb) + 2, b1, sizeof(b1)), 0);
+
+    sshbuf_reset(sb);
+    iron_put_num_sexpr(sb, b2, sizeof(b2));
+    ASSERT_INT_EQ(sshbuf_len(sb), 4);
+    ASSERT_INT_EQ(memcmp(sshbuf_ptr(sb), "2:", 2), 0);
+    ASSERT_INT_EQ(*(sshbuf_ptr(sb) + 2), 0);
+    ASSERT_INT_EQ(*(sshbuf_ptr(sb) + 3), b2[0]);
+
+    sshbuf_reset(sb);
+    iron_put_num_sexpr(sb, b3, sizeof(b3));
+    ASSERT_INT_EQ(sshbuf_len(sb), sizeof(b3) + 4);
+    ASSERT_INT_EQ(memcmp(sshbuf_ptr(sb), "18:", 3), 0);
+    ASSERT_INT_EQ(*(sshbuf_ptr(sb) + 3), 0);
+    ASSERT_INT_EQ(memcmp(sshbuf_ptr(sb) + 4, b3, sizeof(b3)), 0);
+
+    sshbuf_free(sb);
+
+    TEST_DONE();
+}
+
+void
+test_reverse_barray(void)
+{
+    TEST_START("reverse_byte_array");
+
+    u_char be[]   = { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef };
+    u_char be_r[] = { 0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01 };
+    u_char bo[]   = { 0x01, 0x23, 0x45, 0x67, 0xff, 0x89, 0xab, 0xcd, 0xef };
+    u_char bo_r[] = { 0xef, 0xcd, 0xab, 0x89, 0xff, 0x67, 0x45, 0x23, 0x01 };
+                    
+    u_char b[9];
+
+    iron_reverse_byte_array(be, b, sizeof(be));
+    ASSERT_INT_EQ(memcmp(b, be_r, sizeof(be_r)), 0);
+    iron_reverse_byte_array(bo, b, sizeof(bo));
+    ASSERT_INT_EQ(memcmp(b, bo_r, sizeof(bo_r)), 0);
+
+    iron_reverse_byte_array_in_place(be, sizeof(be));
+    ASSERT_INT_EQ(memcmp(be, be_r, sizeof(be_r)), 0);
+    iron_reverse_byte_array_in_place(bo, sizeof(bo));
+    ASSERT_INT_EQ(memcmp(bo, bo_r, sizeof(bo_r)), 0);
+
+    TEST_DONE();
+}
+
+void
+test_sha1(void)
+{
+    TEST_START("compute_sha1_hash");
+
+    u_char * b = "This is a test. It is only a test. If it had been a real emergency, there would be smoke.\n";
+
+    u_char exp[] = { 0x66, 0x4f, 0x72, 0x1e, 0xdc, 0x4e, 0x93, 0x0c, 0xf5, 0xfa,
+                     0x9f, 0x6e, 0x5c, 0x78, 0xe3, 0xf5, 0xf5, 0x09, 0x2e, 0x6f };
+
+    u_char hash[SHA_DIGEST_LENGTH];
+
+    iron_compute_sha1_hash_chars(b, strlen(b), hash);
+    ASSERT_INT_EQ(memcmp(hash, exp, sizeof(hash)), 0);
+
+    struct sshbuf * sb = sshbuf_from(b, strlen(b));
+
+    iron_compute_sha1_hash_sshbuf(sb, hash);
+    ASSERT_INT_EQ(memcmp(hash, exp, sizeof(hash)), 0);
+
+    sshbuf_free(sb);
+
+    TEST_DONE();
+}
+
+//======================================================================================================
+//  Elected to skip unit tests for iron_hashcrypt and iron_compute_rsa_signature, since they are just
+//  wrappers for the openssl functions.
+//======================================================================================================
+
+void
+test_iron_extension_offset(void)
+{
+    TEST_START("iron_extension_offset");
+
+    int retval = iron_extension_offset("abc.iron");
+    ASSERT_INT_EQ(retval, 3);
+    retval = iron_extension_offset("abcdefg");
+    ASSERT_INT_EQ(retval, -1);
+    retval = iron_extension_offset("a");
+    ASSERT_INT_EQ(retval, -1);
+
+    TEST_DONE();
+}

--- a/regress/unittests/irongpg/tests.c
+++ b/regress/unittests/irongpg/tests.c
@@ -1,0 +1,31 @@
+#include "regress/unittests/test_helper/test_helper.h"
+#include "xmalloc.h"
+
+void test_bignums(void);
+void test_int_to_buf(void);
+void test_iron_extension_offset(void);
+void test_packets(void);
+void test_put_num_sexpr(void);
+void test_reverse_barray(void);
+void test_s2k(void);
+void test_sha1(void);
+void test_str2hex(void);
+void test_tags(void);
+
+void
+tests(void)
+{
+    // Initialization
+    ssh_malloc_init();
+
+    test_str2hex();
+    test_bignums();
+    test_int_to_buf();
+    test_put_num_sexpr();
+    test_reverse_barray();
+    test_sha1();
+    test_iron_extension_offset();
+    test_tags();
+    test_packets();
+    test_s2k();
+}


### PR DESCRIPTION
Instead of including all the test code at the end of iron-gpg.c, split
it out into separate files in regress/unittests/irongpg. In order to
allow unit testing of static functions, each test-_something_.c file includes the
corresponding iron/_something_.c source file.

All the initial unit tests are now working in the new framework.

Added unit tests for the rest of util.c funcs.
