### PR TITLE
Fix signature calculation problem.

### DIFF
--- a/iron/gpg-key.c
+++ b/iron/gpg-key.c
@@ -568,8 +568,15 @@ extract_gpg_rsa_pubkey(const struct sshbuf * buf, Key * rsa_key)
                 rsa_key->rsa->e = BN_new();
                 BN_bin2bn(ptr, key_len, rsa_key->rsa->e);
                 retval = 0;
+            } else {
+                error("Key data too long in RSA public key. Unable to retrieve key.");
             }
+        } else {
+            error("Unexpected public key algorithm in RSA public key. Unable to retrieve key.");
         }
+    } else {
+        error("Data in  RSA public key too short. Unable to retrieve key.");
+
     }
 
     return retval;
@@ -954,10 +961,13 @@ decrypt_gpg_sec_parms(const u_char * enc_data, int len, const Key * rsa_pubkey, 
             output = malloc(len);
             if (output != NULL) {
                 if (cipher_crypt(&ciphercontext, 0, output, enc_data, len, 0, 0) != 0) {
+                    error("Decryption of RSA private key failed.");
                     free(output);
                     output = NULL;
                 }
             }
+        } else {
+            error("Failed to initialize to decrypt RSA private key.");
         }
     }
 
@@ -1093,6 +1103,12 @@ extract_gpg_rsa_seckey(const u_char * buf, int buf_len, Key * rsa_key)
                     }
                 }
             }
+
+            if (retval != 0) {
+                error("Unable to extract the RSA private key parameters from the key data.");
+            }
+        } else {
+            error("Could not decrypt RSA private key parameters correctly.");
         }
         free(sec_parms);
     }

--- a/iron/gpg-packet.c
+++ b/iron/gpg-packet.c
@@ -1086,12 +1086,21 @@ finalize_gpg_data_signature_packet(SHA256_CTX * sig_ctx, Key * rsa_key, gpg_pack
     if (get_gpg_secret_signing_key(rsa_key) == 0) {
         BIGNUM * sig = iron_compute_rsa_signature(sig_hash, SHA256_DIGEST_LENGTH, rsa_key);
         iron_put_bignum(sig_pkt->data, sig);
-        BN_clear_free(sig);
-        if ((int)sshbuf_len(sig_pkt->data) == (int)sig_pkt->len) {
-            retval = 0;
-        } else {
-            error("Internal error finalizing signature packet.");
+        retval = 0;
+
+        //  There is a chance that the signature ended up being shorter than the expected length - when it
+        //  is converted to a bignum, leading zero bits are dropped, so if there are 8 or more leading zeroes,
+        //  we will come up short. Just fill out the remainder of the packet with zero bytes so it is the
+        //  length we specified when we wrote the packet headers already.
+        for (int tmp = 0; tmp < RSA_size(rsa_key->rsa) - BN_num_bytes(sig); tmp++) {
+            logit("Padding with %d bytes", RSA_size(rsa_key->rsa) - BN_num_bytes(sig));
+            sshbuf_put_u8(sig_pkt->data, 0);
         }
+        if ((ssize_t) sshbuf_len(sig_pkt->data) != sig_pkt->len) {
+            retval = -1;
+            error("Did not generate complete contents of data signature packet."); 
+        }
+        BN_clear_free(sig);
     }
 
     return retval;
@@ -1116,7 +1125,7 @@ process_data_signature_packet(const u_char * dec_buf, int buf_len, SHA256_CTX * 
     gpg_tag tag;
     size_t len;
     int sig_hdr_len = extract_gpg_tag_and_size(dec_buf, &tag, &len);
-    if (sig_hdr_len < 0 || buf_len < (int) len) return -1;
+    if (sig_hdr_len < 0 || buf_len < (int) (sig_hdr_len + len)) return -1;
     if (tag != GPG_TAG_SIGNATURE) return -2;
 
     const u_char * dptr = dec_buf + sig_hdr_len;
@@ -1165,11 +1174,24 @@ process_data_signature_packet(const u_char * dec_buf, int buf_len, SHA256_CTX * 
         signer_keys = iron_get_user_keys_by_key_id(key_id);
     }
     if (signer_keys != NULL) {
+        //  When we wrote the signature packet, if by some chance the signature had eight or more leading
+        //  zero bits, those got truncated when the signature was converted to a BIGNUM. Needed to do that
+        //  to keep GPG happy. However, if we try to verify that signature, OpenSSL fails immediate. So we
+        //  need to pad with leading zeroes here to make the signature verifiable.
         int sig_len = (*dptr << 8) + *(dptr + 1);   //  Size in bits
         dptr += 2;
         sig_len = (sig_len + 7) / 8;            //  Convert to bytes
 
-        if (RSA_verify(NID_sha256, hash, SHA256_DIGEST_LENGTH, dptr, sig_len, signer_keys->rsa_key.rsa) != 1) {
+        int exp_size = RSA_size(signer_keys->rsa_key.rsa);
+        int short_ct = exp_size - sig_len;
+        u_char tmp_sig[GPG_MAX_KEY_SIZE];
+        if (short_ct != 0) {
+            bzero(tmp_sig, short_ct);
+            memcpy(tmp_sig + short_ct, dptr, sig_len);
+            dptr = tmp_sig;
+        }
+
+        if (RSA_verify(NID_sha256, hash, SHA256_DIGEST_LENGTH, dptr, exp_size, signer_keys->rsa_key.rsa) != 1) {
             error("ERROR: message was signed by user %s, key ID %s,\n       but signature is not correct.",
                   signer_keys->login, hex_id);
             return -13;

--- a/iron/gpg-packet.c
+++ b/iron/gpg-packet.c
@@ -1093,7 +1093,6 @@ finalize_gpg_data_signature_packet(SHA256_CTX * sig_ctx, Key * rsa_key, gpg_pack
         //  we will come up short. Just fill out the remainder of the packet with zero bytes so it is the
         //  length we specified when we wrote the packet headers already.
         for (int tmp = 0; tmp < RSA_size(rsa_key->rsa) - BN_num_bytes(sig); tmp++) {
-            logit("Padding with %d bytes", RSA_size(rsa_key->rsa) - BN_num_bytes(sig));
             sshbuf_put_u8(sig_pkt->data, 0);
         }
         if ((ssize_t) sshbuf_len(sig_pkt->data) != sig_pkt->len) {

--- a/iron/gpg.c
+++ b/iron/gpg.c
@@ -283,6 +283,7 @@ write_encrypted_data_file(FILE * infile, const char * fname, const u_char * sym_
         if (retval == 0) {
             //  From this point, everything is hashed and encrypted. Start with the random prefix bytes, then the
             //  last two bytes repeated.
+            retval = -1;
             u_char input[128];
             u_char output[128];
             randombytes_buf(input, AES_BLOCK_SIZE);

--- a/regress/enc-dec-file.c
+++ b/regress/enc-dec-file.c
@@ -1,3 +1,32 @@
+/*
+ *  Copyright (c) 2016 IronCore Labs, Inc. <bob.wall@ironcorelabs.com>
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without modification,
+ *  are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice, this list
+ *     of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice, this list
+ *     of conditions and the following disclaimer in the documentation and/or other
+ *     materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its contributors may be
+ *     used to endorse or promote products derived from this software without specific prior
+ *     written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
+ *  THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ *  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ *  OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ *  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ *  TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
If an RSA signature is computed for a hash and at least eight of the high order bits are zero, when the signature gets converted to a bignum, those bits get dropped. When that happens, the length of the data in the data signature packet ends up being shorter than the length we put in the header. That was detected and reported as an "internal error".

To fix, removed that check, and instead added padding of zero bytes to make the length of the data signature body match the size in the packet header. It was necessary to do this rather than just write the extra byte(s) of zeros at the start of the Multi-Precision Integer (MPI) because then libgcrypt hated it. However, after doing the padding, the signature woudln't verify, because the OpenSSL RSA verification function won't accept any signature whose length doesn't match the RSA key length. So on verify, I had to make a temporary buffer and pad the start with zeroes to make it match the RSA key length.

Note that this wasn't a problem with the Public Key / UID / Signature packet signature, because we didn't precalculate the length of the packet to write the header before streaming, and because we don't ever verify that signature currently in the irongpg code.
