### PR TITLE
Print list of recipients when putting file

### DIFF
--- a/iron/gpg.c
+++ b/iron/gpg.c
@@ -371,6 +371,16 @@ write_gpg_encrypted_file(const char * fname, char * enc_fname)
                                                        GPG_KEY_ID_FROM_FP(recipient_key[0].signer_fp), outfile);
                     if (retval == 0) {
                         retval = fileno(outfile);
+
+                        char user_list[(IRON_MAX_RECIPIENTS - 1) * (IRON_MAX_LOGIN_LEN + 2) + 1];
+                        user_list[0] = '\0';
+                        for (int ct = 1; ct < recip_ct; ct++) {
+                            if (ct > 1) strcat(user_list, ", ");
+                            strlcat(user_list, recipient_key[ct].login, IRON_MAX_LOGIN_LEN + 1);
+                        }
+                        if (recip_ct > 1) {
+                            logit("Data was shared with user%s %s", (recip_ct > 2) ? "s" : "", user_list);
+                        }
                     }
                 }
             } else {

--- a/iron/recipient.c
+++ b/iron/recipient.c
@@ -31,8 +31,7 @@
 //  always be in the list.
 //================================================================================
 
-#define MAX_RECIPIENTS  11
-static gpg_public_key recipient_list[11];
+static gpg_public_key recipient_list[IRON_MAX_RECIPIENTS];
 static int num_recipients = 0;
 
 /**
@@ -140,7 +139,7 @@ iron_add_recipient(const char * login)
     }
 
     if (retval == 0) {
-        if (num_recipients < MAX_RECIPIENTS) {
+        if (num_recipients < IRON_MAX_RECIPIENTS) {
             gpg_public_key * new_ent = recipient_list + num_recipients;
             strncpy(new_ent->login, login, IRON_MAX_LOGIN_LEN);
             new_ent->login[IRON_MAX_LOGIN_LEN] = 0;

--- a/iron/recipient.h
+++ b/iron/recipient.h
@@ -22,6 +22,8 @@
 #include "iron-gpg.h"
 #include "iron/gpg-internal.h"
 
+#define IRON_MAX_RECIPIENTS 11      //  Max # people with whom to share access to a file, including
+                                    //  the person who generated the file.
 #define IRON_MAX_LOGIN_LEN  32
 
 /*  Public keys (signing and encryption) and associated info for the specified login.  */

--- a/sftp.c
+++ b/sftp.c
@@ -1834,7 +1834,11 @@ parse_dispatch_command(struct sftp_conn *conn, const char *cmd, char **pwd,
 static char *
 prompt(EditLine *el)
 {
+#ifdef IRONCORE
+	return ("ironsftp> ");
+#else
 	return ("sftp> ");
+#endif
 }
 
 /* Display entries in 'list' after skipping the first 'len' chars */
@@ -2284,14 +2288,22 @@ interactive_loop(struct sftp_conn *conn, char *file1, char *file2)
 
 		if (el == NULL) {
 			if (interactive)
+#ifdef IRONCORE
+				printf("ironsftp> ");
+#else
 				printf("sftp> ");
+#endif
 			if (fgets(cmd, sizeof(cmd), infile) == NULL) {
 				if (interactive)
 					printf("\n");
 				break;
 			}
 			if (!interactive) { /* Echo command */
+#ifdef IRONCORE
+				mprintf("ironsftp> %s", cmd);
+#else
 				mprintf("sftp> %s", cmd);
+#endif
 				if (strlen(cmd) > 0 &&
 				    cmd[strlen(cmd) - 1] != '\n')
 					printf("\n");


### PR DESCRIPTION
When uploading a file, print out a list of recipients with whom the file was shared (excluding the current user).

Also fixed interactive prompt for ironsftp.
