### PR TITLE
Updated LICENCE and CREDITS

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,3 +1,5 @@
+IronCore Labs, Inc. - Creators of IronSSH
+
 Tatu Ylonen <ylo@cs.hut.fi> - Creator of SSH
 
 Aaron Campbell, Bob Beck, Markus Friedl, Niels Provos,

--- a/LICENCE
+++ b/LICENCE
@@ -1,3 +1,41 @@
+This file is part of the IronSSH software, which is derived from OpenSSH.
+
+IronSSH contains no GPL code. The new software components that were added to
+OpenSSH to create IronSSH are covered by a BSD 3-clause license:
+
+ *  Copyright (c) 2016 IronCore Labs, Inc. <bob.wall@ironcorelabs.com>
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+
+The remaining sofware components are covered by the previous licenses. These
+are detailed in the original LICENCE contents from the openssh-portable project,
+which follow:
+================================================================================
 This file is part of the OpenSSH software.
 
 The licences which components of this software fall under are as


### PR DESCRIPTION
Updated the LICENCE file to reflect that all new IronSSH components are
covered by a BSD 3-clause license. Updated the CREDITS file to indicate
that IronCore Labs, Inc., created IronSSH.
